### PR TITLE
Implement QuietEstimate MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Thumbs.db
 
 # Uploads
 app/static/uploads/*
+app/leads.json

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,58 +1,546 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const addressInput = document.getElementById('address');
-  const suburbSelect = document.getElementById('suburb');
-  const bedroomsInput = document.getElementById('bedrooms');
-  const bathroomsInput = document.getElementById('bathrooms');
-  const parkingInput = document.getElementById('parking');
-  const landSizeInput = document.getElementById('land_size');
+const { useState, useEffect, useMemo, useCallback, useRef } = React;
 
-  async function lookupProperty(address) {
-    if (!address) {
+const currencyFormatter = new Intl.NumberFormat('en-AU', {
+  style: 'currency',
+  currency: 'AUD',
+  maximumFractionDigits: 0,
+});
+
+const defaultAddress = () => ({
+  fullAddress: '',
+  suburb: '',
+  state: '',
+  postcode: '',
+  lat: null,
+  lng: null,
+});
+
+const defaultDetails = () => ({
+  propertyType: 'house',
+  bedrooms: '',
+  landSize: '',
+});
+
+const defaultOptions = () => ({
+  emailEstimate: false,
+  connectToAgent: false,
+});
+
+const defaultContact = () => ({
+  userName: '',
+  userEmail: '',
+  userPhone: '',
+});
+
+function formatCurrency(value) {
+  if (!value && value !== 0) return '—';
+  return currencyFormatter.format(value);
+}
+
+function StepIndicator({ step }) {
+  return (
+    <div className="step-indicator" aria-label={`Step ${step} of 3`}>
+      {[1, 2, 3].map((idx) => (
+        <div key={idx} className={`step-dot ${idx <= step ? 'active' : ''}`}></div>
+      ))}
+    </div>
+  );
+}
+
+function parsePlace(place) {
+  if (!place || !place.address_components) return null;
+  const findComponent = (type) => {
+    const component = place.address_components.find((item) => item.types.includes(type));
+    return component ? component.long_name : '';
+  };
+  return {
+    fullAddress: place.formatted_address || '',
+    suburb: findComponent('locality') || findComponent('postal_town') || '',
+    state: findComponent('administrative_area_level_1') || '',
+    postcode: findComponent('postal_code') || '',
+    lat: place.geometry?.location?.lat?.() ?? null,
+    lng: place.geometry?.location?.lng?.() ?? null,
+  };
+}
+
+function usePlacesAutocomplete(isActive, onSelect) {
+  const inputRef = useRef(null);
+  useEffect(() => {
+    if (!isActive || !inputRef.current) return;
+    if (!(window.google && window.google.maps && window.google.maps.places)) return;
+    const autocomplete = new window.google.maps.places.Autocomplete(inputRef.current, {
+      componentRestrictions: { country: 'au' },
+      fields: ['formatted_address', 'address_components', 'geometry'],
+      types: ['address'],
+    });
+    const listener = autocomplete.addListener('place_changed', () => {
+      const place = autocomplete.getPlace();
+      const parsed = parsePlace(place);
+      if (parsed) {
+        onSelect(parsed);
+      }
+    });
+    return () => {
+      window.google.maps.event.clearInstanceListeners(autocomplete);
+      listener?.remove?.();
+    };
+  }, [isActive, onSelect]);
+  return inputRef;
+}
+
+function QuietEstimateApp() {
+  const [isWidgetOpen, setWidgetOpen] = useState(false);
+  const [step, setStep] = useState(1);
+  const [address, setAddress] = useState(defaultAddress);
+  const [details, setDetails] = useState(defaultDetails);
+  const [options, setOptions] = useState(defaultOptions);
+  const [contact, setContact] = useState(defaultContact);
+  const [estimate, setEstimate] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [leadError, setLeadError] = useState('');
+
+  const resetState = () => {
+    setStep(1);
+    setAddress(defaultAddress());
+    setDetails(defaultDetails());
+    setOptions(defaultOptions());
+    setContact(defaultContact());
+    setEstimate(null);
+    setError('');
+    setLeadError('');
+  };
+
+  const openWidget = () => {
+    resetState();
+    setWidgetOpen(true);
+  };
+
+  const closeWidget = () => {
+    setWidgetOpen(false);
+  };
+
+  const handleManualAddressChange = (event) => {
+    const value = event.target.value;
+    setAddress((prev) => ({ ...prev, fullAddress: value }));
+  };
+
+  const handleAddressDetailsChange = (field, value) => {
+    setAddress((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleDetailsChange = (field, value) => {
+    setDetails((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleOptionsChange = (field, checked) => {
+    setOptions((prev) => ({ ...prev, [field]: checked }));
+    if (!checked) {
+      setLeadError('');
+    }
+  };
+
+  const handleContactChange = (field, value) => {
+    setContact((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const isGoogleReady = Boolean(window.google && window.google.maps && window.google.maps.places);
+  const addressInputRef = usePlacesAutocomplete(isWidgetOpen && step === 1, (parsed) => {
+    setAddress((prev) => ({ ...prev, ...parsed }));
+  });
+
+  const addressComplete = useMemo(() => {
+    const fields = ['fullAddress', 'suburb', 'state', 'postcode'];
+    return fields.every((field) => {
+      const value = address[field];
+      return typeof value === 'number' ? true : Boolean(value && String(value).trim());
+    });
+  }, [address]);
+
+  const requestSignature = useMemo(() => {
+    return JSON.stringify({
+      fullAddress: address.fullAddress,
+      suburb: address.suburb,
+      state: address.state,
+      postcode: address.postcode,
+      propertyType: details.propertyType,
+      bedrooms: details.bedrooms,
+      landSize: details.landSize,
+    });
+  }, [address, details]);
+
+  useEffect(() => {
+    if (!isWidgetOpen || step !== 3 || !addressComplete) {
       return;
     }
+    setError('');
+    setLoading(true);
+    setEstimate(null);
+    const controller = new AbortController();
+    const body = {
+      ...address,
+      propertyType: details.propertyType,
+      bedrooms: details.bedrooms ? Number(details.bedrooms) : undefined,
+      landSize: details.landSize ? Number(details.landSize) : undefined,
+    };
+    fetch('/api/estimate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || 'Unable to fetch estimate');
+        }
+        return response.json();
+      })
+      .then((data) => {
+        setEstimate(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError') return;
+        setError(err.message);
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [isWidgetOpen, step, addressComplete, requestSignature]);
+
+  const goBack = () => {
+    if (step === 1) {
+      closeWidget();
+    } else {
+      setStep((prev) => Math.max(prev - 1, 1));
+    }
+  };
+
+  const goNext = () => {
+    if (step === 3) return;
+    if (step === 1 && !addressComplete) return;
+    setStep((prev) => Math.min(prev + 1, 3));
+  };
+
+  const submitLeadIfNeeded = useCallback(async () => {
+    if (!estimate) return;
+    if (!options.emailEstimate && !options.connectToAgent) return;
+    const requireEmail = options.emailEstimate;
+    const requireContact = options.connectToAgent;
+    if (requireEmail && !contact.userEmail) {
+      setLeadError('Please add an email so we can send the estimate.');
+      return Promise.reject(new Error('Missing email'));
+    }
+    if (requireContact && !contact.userEmail && !contact.userPhone) {
+      setLeadError('Add at least an email or phone so an agent can respond.');
+      return Promise.reject(new Error('Missing contact details'));
+    }
+
+    const payload = {
+      ...address,
+      propertyType: details.propertyType,
+      bedrooms: details.bedrooms ? Number(details.bedrooms) : undefined,
+      landSize: details.landSize ? Number(details.landSize) : undefined,
+      ...estimate,
+      emailEstimate: options.emailEstimate,
+      connectToAgent: options.connectToAgent,
+      userName: contact.userName,
+      userEmail: contact.userEmail,
+      userPhone: contact.userPhone,
+    };
     try {
-      const response = await fetch(`/api/property-info?address=${encodeURIComponent(address)}`);
+      const response = await fetch('/api/leads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
       if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setLeadError(data.error || 'Unable to submit request.');
+        return Promise.reject(new Error(data.error || 'Lead error'));
+      }
+      setLeadError('');
+      return response.json();
+    } catch (err) {
+      setLeadError('Something went wrong while sending your preferences.');
+      return Promise.reject(err);
+    }
+  }, [estimate, options, contact, address, details]);
+
+  const finishFlow = async () => {
+    if (options.emailEstimate || options.connectToAgent) {
+      try {
+        await submitLeadIfNeeded();
+      } catch (error) {
         return;
       }
-      const data = await response.json();
-      populateFromRecord(data);
-    } catch (error) {
-      console.warn('Unable to fetch property info', error);
     }
-  }
+    closeWidget();
+  };
 
-  function populateFromRecord(record) {
-    if (!record) return;
-    if (record.suburb) {
-      const option = Array.from(suburbSelect.options).find((opt) => opt.value === record.suburb);
-      if (option) {
-        suburbSelect.value = record.suburb;
-      }
-    }
-    if (record.bedrooms != null && record.bedrooms !== '') {
-      bedroomsInput.value = record.bedrooms;
-    }
-    if (record.bathrooms != null && record.bathrooms !== '') {
-      bathroomsInput.value = record.bathrooms;
-    }
-    if (record.parking != null && record.parking !== '') {
-      parkingInput.value = record.parking;
-    }
-    if (record.land_size != null && record.land_size !== '') {
-      landSizeInput.value = record.land_size;
-    }
-  }
+  return (
+    <>
+      <main>
+        <section className="hero">
+          <div className="hero-content">
+            <p className="trust-badge">QuietEstimate</p>
+            <h1>Check your home’s value with a calm, guided experience.</h1>
+            <p>Three gentle steps to an instant, data-backed estimate. No agents calling unless you ask.</p>
+            <button className="primary-cta" onClick={openWidget}>Get my free estimate</button>
+            <div className="trust-badges" aria-label="Trust badges">
+              <span className="trust-badge">Privacy-first</span>
+              <span className="trust-badge">Powered by suburb medians</span>
+            </div>
+          </div>
+          <div className="preview-card">
+            <h3>What you’ll receive</h3>
+            <p>A personalised value range plus suburb context delivered in under 30 seconds.</p>
+            <div className="preview-range">
+              <strong>$1.15m – $1.28m</strong>
+              <span>Confidence: Medium</span>
+            </div>
+            <div className="preview-meta">
+              <span>Suburb median: $1.20m</span>
+              <span>Updated weekly</span>
+            </div>
+          </div>
+        </section>
+        <section className="highlights">
+          <article className="highlight-card">
+            <h4>Three steps</h4>
+            <p>Address, a few optional details and you’re done.</p>
+          </article>
+          <article className="highlight-card">
+            <h4>No pressure</h4>
+            <p>See the estimate instantly. Opt in to email or agent help only if it suits you.</p>
+          </article>
+          <article className="highlight-card">
+            <h4>Local context</h4>
+            <p>We surface suburb medians and sales volumes so you can gauge confidence.</p>
+          </article>
+        </section>
+      </main>
 
-  let fetchTimeout;
-  addressInput.addEventListener('input', () => {
-    clearTimeout(fetchTimeout);
-    fetchTimeout = setTimeout(() => {
-      lookupProperty(addressInput.value.trim());
-    }, 400);
-  });
+      {isWidgetOpen && (
+        <div className="widget-overlay" role="dialog" aria-modal="true">
+          <div className="widget-panel">
+            <div className="widget-header">
+              <div>
+                <p style={{ margin: 0, color: '#64748b', fontWeight: 500 }}>QuietEstimate</p>
+                <h2 style={{ margin: 0 }}>Let’s get your estimate</h2>
+              </div>
+              <button className="close-btn" onClick={closeWidget} aria-label="Close">×</button>
+            </div>
+            <StepIndicator step={step} />
 
-  addressInput.addEventListener('change', () => {
-    lookupProperty(addressInput.value.trim());
-  });
-});
+            {step === 1 && (
+              <div className="form-stack">
+                <div>
+                  <label htmlFor="addressInput">Property address</label>
+                  <input
+                    id="addressInput"
+                    ref={addressInputRef}
+                    type="text"
+                    placeholder="Start typing your Australian address"
+                    value={address.fullAddress}
+                    onChange={handleManualAddressChange}
+                  />
+                  {!isGoogleReady && (
+                    <small style={{ color: '#475569' }}>
+                      Google Places isn’t connected in this demo, so enter suburb, state and postcode manually below.
+                    </small>
+                  )}
+                </div>
+                <div className="inline-inputs">
+                  <div>
+                    <label htmlFor="suburbInput">Suburb</label>
+                    <input
+                      id="suburbInput"
+                      type="text"
+                      value={address.suburb}
+                      onChange={(event) => handleAddressDetailsChange('suburb', event.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="stateInput">State</label>
+                    <input
+                      id="stateInput"
+                      type="text"
+                      value={address.state}
+                      onChange={(event) => handleAddressDetailsChange('state', event.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="postcodeInput">Postcode</label>
+                    <input
+                      id="postcodeInput"
+                      type="text"
+                      value={address.postcode}
+                      onChange={(event) => handleAddressDetailsChange('postcode', event.target.value)}
+                    />
+                  </div>
+                </div>
+                <div className="widget-actions">
+                  <button className="secondary-button" onClick={closeWidget}>Cancel</button>
+                  <button className="widget-button" onClick={goNext} disabled={!addressComplete}>
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {step === 2 && (
+              <div className="form-stack">
+                <div>
+                  <label>Property type</label>
+                  <div className="radio-group">
+                    {['house', 'unit'].map((type) => (
+                      <button
+                        key={type}
+                        type="button"
+                        className={`pill-option ${details.propertyType === type ? 'active' : ''}`}
+                        onClick={() => handleDetailsChange('propertyType', type)}
+                      >
+                        {type === 'house' ? 'House' : 'Unit / apartment'}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="inline-inputs">
+                  <div>
+                    <label htmlFor="bedroomsInput">Bedrooms (optional)</label>
+                    <input
+                      id="bedroomsInput"
+                      type="number"
+                      min="0"
+                      value={details.bedrooms}
+                      onChange={(event) => handleDetailsChange('bedrooms', event.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="landSizeInput">Land size m² (optional)</label>
+                    <input
+                      id="landSizeInput"
+                      type="number"
+                      min="0"
+                      value={details.landSize}
+                      onChange={(event) => handleDetailsChange('landSize', event.target.value)}
+                    />
+                  </div>
+                </div>
+                <div className="widget-actions">
+                  <button className="secondary-button" onClick={goBack}>Back</button>
+                  <button className="widget-button" onClick={goNext}>Next</button>
+                </div>
+              </div>
+            )}
+
+            {step === 3 && (
+              <div className="form-stack">
+                {loading && (
+                  <div>
+                    <div className="spinner" aria-label="Loading estimate" />
+                  </div>
+                )}
+                {error && <div className="error-box">{error}</div>}
+                {estimate && !loading && (
+                  <div className="estimate-panel">
+                    <p style={{ margin: 0, textTransform: 'uppercase', letterSpacing: '0.1em', fontSize: '0.85rem' }}>
+                      Estimated range
+                    </p>
+                    <div className="estimate-range">
+                      {formatCurrency(estimate.estimateLow)} – {formatCurrency(estimate.estimateHigh)}
+                    </div>
+                    <div className="estimate-meta">
+                      <span>Confidence: {estimate.confidence}</span>
+                      <span>
+                        Suburb median {details.propertyType === 'house' ? 'house' : 'unit'} price:{' '}
+                        {formatCurrency(
+                          details.propertyType === 'house'
+                            ? estimate.suburbStats.medianHousePrice
+                            : estimate.suburbStats.medianUnitPrice
+                        )}
+                      </span>
+                      <span>
+                        Recent sales volume:{' '}
+                        {details.propertyType === 'house'
+                          ? estimate.suburbStats.numHouseSales12m
+                          : estimate.suburbStats.numUnitSales12m}
+                      </span>
+                    </div>
+                  </div>
+                )}
+
+                <div className="checkbox-group">
+                  <label className="checkbox-row">
+                    <input
+                      type="checkbox"
+                      checked={options.emailEstimate}
+                      onChange={(event) => handleOptionsChange('emailEstimate', event.target.checked)}
+                    />
+                    <span>Email this estimate to me</span>
+                  </label>
+                  <label className="checkbox-row">
+                    <input
+                      type="checkbox"
+                      checked={options.connectToAgent}
+                      onChange={(event) => handleOptionsChange('connectToAgent', event.target.checked)}
+                    />
+                    <span>Introduce me to a calm local agent</span>
+                  </label>
+                </div>
+
+                {(options.emailEstimate || options.connectToAgent) && (
+                  <div className="inline-inputs">
+                    <div>
+                      <label htmlFor="nameInput">Name (optional)</label>
+                      <input
+                        id="nameInput"
+                        type="text"
+                        value={contact.userName}
+                        onChange={(event) => handleContactChange('userName', event.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="emailInput">Email</label>
+                      <input
+                        id="emailInput"
+                        type="email"
+                        value={contact.userEmail}
+                        onChange={(event) => handleContactChange('userEmail', event.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="phoneInput">Phone (optional)</label>
+                      <input
+                        id="phoneInput"
+                        type="tel"
+                        value={contact.userPhone}
+                        onChange={(event) => handleContactChange('userPhone', event.target.value)}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {leadError && <div className="error-box">{leadError}</div>}
+
+                <p className="disclaimer">
+                  Estimates are price guides only and not formal valuations. Contact details are only shared if you opt in.
+                </p>
+
+                <div className="widget-actions">
+                  <button className="secondary-button" onClick={goBack}>Back</button>
+                  <button className="widget-button" onClick={finishFlow} disabled={loading}>
+                    {options.emailEstimate || options.connectToAgent ? 'Send & close' : 'Done'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<QuietEstimateApp />);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,260 +1,353 @@
 :root {
-  --background: #f4f6fb;
-  --panel: #ffffff;
-  --border: #d7deea;
-  --primary: #2f5dff;
-  --primary-dark: #2144c4;
-  --text: #1a2240;
-  --muted: #5f6b88;
-  --success: #0f9d58;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background: #f5f7fb;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: var(--background);
-  color: var(--text);
+  background: #f5f7fb;
+  color: #0f172a;
+  min-height: 100vh;
 }
 
-h1, h2, h3 {
-  font-weight: 600;
-  color: var(--text);
+button {
+  font-family: inherit;
 }
 
-p {
-  color: var(--muted);
-}
-
-.container {
+main {
+  padding: 4rem 1.5rem 3rem;
   max-width: 1100px;
   margin: 0 auto;
-  padding: 0 1.5rem;
 }
 
-.site-header {
-  background: linear-gradient(135deg, #2f5dff, #6f86ff);
-  color: white;
-  padding: 2.5rem 0 2rem;
-  box-shadow: 0 4px 20px rgba(47, 93, 255, 0.2);
-}
-
-.site-header h1 {
-  margin: 0 0 0.5rem;
-  font-size: 2.25rem;
-}
-
-.site-header .tagline {
-  margin: 0;
-  color: rgba(255, 255, 255, 0.9);
-}
-
-.site-footer {
-  padding: 2rem 0 3rem;
-  text-align: center;
-  color: var(--muted);
-}
-
-.panel {
-  background: var(--panel);
-  border-radius: 16px;
-  padding: 2rem;
-  margin: 2rem 0;
-  box-shadow: 0 15px 45px rgba(15, 23, 42, 0.08);
-}
-
-.section-intro {
-  margin-top: 0.25rem;
-}
-
-.appraisal-form {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
-.form-grid {
+.hero {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: 2.5rem;
+  margin-bottom: 3rem;
 }
 
-.form-group {
-  display: flex;
-  flex-direction: column;
+.hero-content h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  margin: 0 0 1rem;
 }
 
-.form-group label {
-  font-weight: 500;
-  margin-bottom: 0.35rem;
+.hero-content p {
+  margin: 0 0 1.5rem;
+  color: #51607a;
+  font-size: 1.125rem;
 }
 
-.form-group input,
-.form-group select {
-  font: inherit;
-  padding: 0.65rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: #f8f9fe;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.form-group input:focus,
-.form-group select:focus {
-  border-color: var(--primary);
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(47, 93, 255, 0.15);
-}
-
-.form-group.full-width {
-  grid-column: 1 / -1;
-}
-
-.feature-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
-}
-
-.feature-option {
-  display: flex;
-  gap: 0.75rem;
-  align-items: flex-start;
-  padding: 0.85rem 1rem;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  background: #f8faff;
-  cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.feature-option:hover,
-.feature-option:focus-within {
-  border-color: var(--primary);
-  box-shadow: 0 6px 18px rgba(47, 93, 255, 0.15);
-  background: #eef3ff;
-}
-
-.feature-option input {
-  margin-top: 0.2rem;
-}
-
-.feature-option strong {
-  display: block;
-  color: var(--text);
-}
-
-.feature-option small {
-  color: var(--muted);
-}
-
-.primary-button {
-  align-self: flex-start;
-  padding: 0.85rem 1.75rem;
+.primary-cta {
+  padding: 0.95rem 2.25rem;
   border-radius: 999px;
   border: none;
-  background: var(--primary);
-  color: white;
+  font-size: 1rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  background: linear-gradient(135deg, #3056ff, #5a73ff);
+  color: white;
   cursor: pointer;
-  transition: transform 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 15px 30px rgba(48, 86, 255, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.primary-button:hover {
-  background: var(--primary-dark);
-  transform: translateY(-1px);
-  box-shadow: 0 10px 25px rgba(47, 93, 255, 0.25);
+.primary-cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(48, 86, 255, 0.3);
 }
 
-.results .estimate {
+.trust-badges {
   display: flex;
-  align-items: baseline;
-  gap: 1.5rem;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
-.estimate-label {
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 0.8rem;
-  color: var(--muted);
+.trust-badge {
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  color: #51607a;
+  font-weight: 500;
 }
 
-.estimate-value {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--primary-dark);
+.preview-card {
+  background: white;
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.08);
+  position: relative;
+  overflow: hidden;
 }
 
-.breakdown ul {
-  list-style: none;
-  padding: 0;
-  margin: 1.5rem 0 0;
+.preview-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(91, 115, 255, 0.25), transparent 55%);
+  pointer-events: none;
+}
+
+.preview-card h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.25rem;
+}
+
+.preview-card p {
+  margin: 0 0 1.5rem;
+  color: #51607a;
+}
+
+.preview-range {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.preview-range strong {
+  font-size: 2rem;
+}
+
+.preview-meta {
+  display: flex;
+  justify-content: space-between;
+  color: #51607a;
+  font-size: 0.95rem;
+}
+
+section.highlights {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1rem;
 }
 
-.breakdown li {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
-  background: #f9fbff;
+.highlight-card {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  box-shadow: 0 10px 35px rgba(15, 23, 42, 0.05);
 }
 
-.breakdown-label {
+.highlight-card h4 {
+  margin: 0 0 0.5rem;
+}
+
+.highlight-card p {
+  margin: 0;
+  color: #51607a;
+}
+
+.widget-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 20;
+}
+
+.widget-panel {
+  background: white;
+  border-radius: 28px;
+  width: min(900px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 2.25rem;
+  box-shadow: 0 40px 120px rgba(15, 23, 42, 0.25);
+}
+
+.widget-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.close-btn {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #64748b;
+}
+
+.step-indicator {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.step-dot {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.4);
+}
+
+.step-dot.active {
+  background: linear-gradient(135deg, #3056ff, #5a73ff);
+}
+
+.form-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+label {
   font-weight: 600;
   margin-bottom: 0.35rem;
 }
 
-.breakdown-value {
-  font-size: 1.1rem;
-  color: var(--text);
-  margin-bottom: 0.25rem;
-}
-
-.breakdown-description {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-.table-wrapper {
-  overflow-x: auto;
-}
-
-table {
+input,
+select,
+textarea {
   width: 100%;
-  border-collapse: collapse;
-  min-width: 600px;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: #f8fafc;
+  font-size: 1rem;
 }
 
-thead {
-  background: #eef1fb;
+.radio-group,
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-thead th {
-  text-align: left;
-  padding: 0.85rem;
+.pill-option {
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  padding: 0.6rem 1.25rem;
+  cursor: pointer;
+  background: white;
+  transition: all 0.2s ease;
+}
+
+.pill-option.active {
+  background: #3056ff;
+  color: white;
+  border-color: #3056ff;
+}
+
+.widget-actions {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.secondary-button {
+  border: none;
+  background: transparent;
+  color: #64748b;
   font-weight: 600;
-  font-size: 0.9rem;
-  color: var(--muted);
+  cursor: pointer;
 }
 
-tbody td {
-  padding: 0.85rem;
-  border-bottom: 1px solid #e4e8f5;
+.widget-button {
+  padding: 0.85rem 1.75rem;
+  border-radius: 16px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: #0f172a;
+  color: white;
 }
 
-tbody tr:hover {
-  background: #f5f7ff;
+.widget-button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
-@media (max-width: 720px) {
-  .results .estimate {
-    flex-direction: column;
-    align-items: flex-start;
+.estimate-panel {
+  border-radius: 24px;
+  background: #0f172a;
+  color: white;
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.estimate-range {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+}
+
+.estimate-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.inline-inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #0f172a;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid rgba(48, 86, 255, 0.2);
+  border-top-color: #3056ff;
+  animation: spin 1s linear infinite;
+  margin: 1rem auto;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
   }
+}
 
-  .estimate-value {
-    font-size: 2rem;
+.error-box {
+  background: #fee2e2;
+  color: #7f1d1d;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+}
+
+.disclaimer {
+  font-size: 0.9rem;
+  color: #475569;
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .widget-panel {
+    padding: 1.5rem;
+    border-radius: 20px;
+  }
+  .widget-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .widget-button,
+  .secondary-button {
+    width: 100%;
+    text-align: center;
   }
 }

--- a/app/suburb_stats.json
+++ b/app/suburb_stats.json
@@ -1,0 +1,56 @@
+[
+  {
+    "state": "NSW",
+    "suburb": "Newtown",
+    "postcode": "2042",
+    "median_house_price_12m": 1250000,
+    "median_unit_price_12m": 810000,
+    "num_house_sales_12m": 148,
+    "num_unit_sales_12m": 92
+  },
+  {
+    "state": "NSW",
+    "suburb": "Bondi",
+    "postcode": "2026",
+    "median_house_price_12m": 2850000,
+    "median_unit_price_12m": 1500000,
+    "num_house_sales_12m": 86,
+    "num_unit_sales_12m": 210
+  },
+  {
+    "state": "VIC",
+    "suburb": "Fitzroy",
+    "postcode": "3065",
+    "median_house_price_12m": 1600000,
+    "median_unit_price_12m": 900000,
+    "num_house_sales_12m": 74,
+    "num_unit_sales_12m": 120
+  },
+  {
+    "state": "VIC",
+    "suburb": "Richmond",
+    "postcode": "3121",
+    "median_house_price_12m": 1450000,
+    "median_unit_price_12m": 860000,
+    "num_house_sales_12m": 112,
+    "num_unit_sales_12m": 168
+  },
+  {
+    "state": "QLD",
+    "suburb": "Taringa",
+    "postcode": "4068",
+    "median_house_price_12m": 1200000,
+    "median_unit_price_12m": 650000,
+    "num_house_sales_12m": 59,
+    "num_unit_sales_12m": 95
+  },
+  {
+    "state": "SA",
+    "suburb": "Norwood",
+    "postcode": "5067",
+    "median_house_price_12m": 1150000,
+    "median_unit_price_12m": 640000,
+    "num_house_sales_12m": 68,
+    "num_unit_sales_12m": 88
+  }
+]

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>QuietEstimate – Calm property price guides</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    {% if google_api_key %}
+    <script
+      src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places"
+      async
+      defer
+    ></script>
+    {% endif %}
+    <script type="text/babel" src="{{ url_for('static', filename='app.js') }}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the Flask landing page with the QuietEstimate marketing hero and multi-step onboarding widget powered by a lightweight React client
- add suburb median sample data plus mocked /api/estimate logic that returns a range with confidence and suburb context
- scaffold a /api/leads endpoint that validates opt-in requests and captures them locally so the optional email/agent flow is wired up end-to-end

## Testing
- `python -m compileall app`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919aff26ba48331825f55614079435e)